### PR TITLE
Bug/refactor problem details

### DIFF
--- a/frontend/src/app/annotate/annotation-input/annotation-input.component.html
+++ b/frontend/src/app/annotate/annotation-input/annotation-input.component.html
@@ -8,9 +8,7 @@
 @if (form$ | async; as inputForm) {
 <div class="card">
     <div class="card-body">
-        @if (problemDetails$ | async; as details) {
-        <la-problem-details [problemDetails]="details" />
-        }
+        <la-problem-details />
         <div class="input-form-container">
             <la-premises-form class="subform" [form]="inputForm" />
             <la-knowledge-base-form class="subform" [form]="inputForm" />

--- a/frontend/src/app/annotate/annotation-input/annotation-input.component.html
+++ b/frontend/src/app/annotate/annotation-input/annotation-input.component.html
@@ -8,7 +8,7 @@
 @if (form$ | async; as inputForm) {
 <div class="card">
     <div class="card-body">
-        <la-problem-details />
+        <la-problem-details [problem]="problem$ | async" />
         <div class="input-form-container">
             <la-premises-form class="subform" [form]="inputForm" />
             <la-knowledge-base-form class="subform" [form]="inputForm" />

--- a/frontend/src/app/annotate/annotation-input/annotation-input.component.ts
+++ b/frontend/src/app/annotate/annotation-input/annotation-input.component.ts
@@ -63,52 +63,7 @@ export class AnnotationInputComponent {
         initialValue: null,
     });
 
-    public problemDetails$ = this.problem$.pipe(
-        map((response) => this.extractDetails(response))
-    );
-
     public submit$ = new Subject<void>();
-
-    private getJudgement(response: ProblemResponse): Judgement {
-        // This should never happen, as we check for a problem in the calling
-        // function, but TypeScript does not know this.
-        if (!response.problem) {
-            return Judgement.UNKNOWN;
-        }
-        switch (response.type) {
-            case Dataset.SICK:
-                switch (response.problem.entailmentLabel) {
-                    case "ENTAILMENT":
-                        return Judgement.ENTAILMENT;
-                    case "CONTRADICTION":
-                        return Judgement.CONTRADICTION;
-                    case "NEUTRAL":
-                        return Judgement.NEUTRAL;
-                }
-            case Dataset.FRACAS:
-                switch (response.problem.fracasAnswer) {
-                    case "yes":
-                        return Judgement.ENTAILMENT;
-                    case "no":
-                        return Judgement.CONTRADICTION;
-                    case "unknown":
-                        return Judgement.NEUTRAL;
-                    case "undefined":
-                        return Judgement.UNKNOWN;
-                }
-            case Dataset.SNLI:
-                switch (response.problem.goldLabel) {
-                    case "entailment":
-                        return Judgement.ENTAILMENT;
-                    case "contradiction":
-                        return Judgement.CONTRADICTION;
-                    case "neutral":
-                        return Judgement.NEUTRAL;
-                    case "none":
-                        return Judgement.UNKNOWN;
-                }
-        }
-    }
 
     public faCheck = faCheck;
 
@@ -178,43 +133,5 @@ export class AnnotationInputComponent {
             }),
             kbItems: new FormArray<KnowledgeBaseItemsForm>([]),
         });
-    }
-
-    private extractDetails(
-        response: ProblemResponse | null
-    ): ProblemDetails | null {
-        if (!response?.problem) {
-            return null;
-        }
-        const judgement = this.getJudgement(response);
-        switch (response.type) {
-            case Dataset.SICK:
-                return {
-                    problemId: response.problem.pairId.toString(),
-                    dataset: response.type,
-                    judgement,
-                    section: null,
-                    subsection: null,
-                    comment: null,
-                };
-            case Dataset.FRACAS:
-                return {
-                    problemId: response.problem.fracasId.toString(),
-                    dataset: response.type,
-                    judgement,
-                    section: response.problem.sectionName,
-                    subsection: response.problem.subsectionName,
-                    comment: response.problem.note || null,
-                };
-            case Dataset.SNLI:
-                return {
-                    problemId: response.problem.pairId.toString(),
-                    dataset: response.type,
-                    judgement,
-                    section: null,
-                    subsection: null,
-                    comment: null,
-                };
-        }
     }
 }

--- a/frontend/src/app/annotate/annotation-input/problem-details/problem-details.component.html
+++ b/frontend/src/app/annotate/annotation-input/problem-details/problem-details.component.html
@@ -1,8 +1,9 @@
+@if (problemDetails(); as details) {
 <div class="problem-details-container">
     <div class="judgement-badge-container">
-        <span>Judgement:</span>
+        <span i18n>Judgement:</span>
         <la-judgement-badge
-            [judgement]="problemDetails().judgement"
+            [judgement]="details.judgement"
         ></la-judgement-badge>
     </div>
 
@@ -10,19 +11,18 @@
         <tbody>
             <tr>
                 <td class="text-muted" i18n>ID:</td>
-                <td>{{ problemDetails().problemId }}</td>
+                <td>{{ details.problemId }}</td>
             </tr>
             <tr>
                 <td class="text-muted" i18n>Dataset:</td>
-                <td>{{ problemDetails().dataset }}</td>
+                <td>{{ details.dataset }}</td>
             </tr>
             @if (sectionString()) {
-                <tr>
-                    <td class="text-muted" i18n>Section:</td>
-                    <td>{{ sectionString() }}</td>
-                </tr>
-            }
-            @if (problemDetails().comment) {
+            <tr>
+                <td class="text-muted" i18n>Section:</td>
+                <td>{{ sectionString() }}</td>
+            </tr>
+            } @if (details.comment) {
             <tr>
                 <td class="text-muted">
                     <span i18n>Comment:</span>
@@ -34,9 +34,12 @@
                         i18n-ngbTooltip
                     />
                 </td>
-                <td><i>{{ problemDetails().comment }}</i></td>
+                <td>
+                    <i>{{ details.comment }}</i>
+                </td>
             </tr>
             }
         </tbody>
     </table>
 </div>
+}

--- a/frontend/src/app/annotate/annotation-input/problem-details/problem-details.component.ts
+++ b/frontend/src/app/annotate/annotation-input/problem-details/problem-details.component.ts
@@ -1,9 +1,11 @@
-import { Component, computed, input } from "@angular/core";
-import { Dataset, Judgement } from "../../../types";
+import { Component, computed } from "@angular/core";
+import { Dataset, Judgement, ProblemResponse } from "../../../types";
 import { JudgementBadgeComponent } from "./judgement-badge/judgement-badge.component";
 import { faQuestionCircle } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeModule } from "@fortawesome/angular-fontawesome";
 import { NgbTooltipModule } from "@ng-bootstrap/ng-bootstrap";
+import { AnnotateService } from "../../../services/annotate.service";
+import { toSignal } from "@angular/core/rxjs-interop";
 
 export interface ProblemDetails {
     problemId: string;
@@ -22,12 +24,25 @@ export interface ProblemDetails {
     styleUrl: "./problem-details.component.scss",
 })
 export class ProblemDetailsComponent {
-    public problemDetails = input.required<ProblemDetails>();
+    constructor(private annotateService: AnnotateService) {}
+
+    private problem = toSignal(this.annotateService.problem$);
+
+    public problemDetails = computed(() => {
+        const problem = this.problem();
+        if (!problem) {
+            return null;
+        }
+        return this.extractDetails(problem);
+    });
 
     public faQuestionCircle = faQuestionCircle;
 
     public sectionString = computed<string | null>(() => {
         const problemDetails = this.problemDetails();
+        if (!problemDetails) {
+            return null;
+        }
         const section = problemDetails.section;
         const subsection = problemDetails.subsection;
         if (section && subsection) {
@@ -39,4 +54,83 @@ export class ProblemDetailsComponent {
         }
         return null;
     });
+
+    private extractDetails(
+        response: ProblemResponse | null
+    ): ProblemDetails | null {
+        if (!response?.problem) {
+            return null;
+        }
+        const judgement = this.getJudgement(response);
+        switch (response.type) {
+            case Dataset.SICK:
+                return {
+                    problemId: response.problem.pairId.toString(),
+                    dataset: response.type,
+                    judgement,
+                    section: null,
+                    subsection: null,
+                    comment: null,
+                };
+            case Dataset.FRACAS:
+                return {
+                    problemId: response.problem.fracasId.toString(),
+                    dataset: response.type,
+                    judgement,
+                    section: response.problem.sectionName,
+                    subsection: response.problem.subsectionName,
+                    comment: response.problem.note || null,
+                };
+            case Dataset.SNLI:
+                return {
+                    problemId: response.problem.pairId.toString(),
+                    dataset: response.type,
+                    judgement,
+                    section: null,
+                    subsection: null,
+                    comment: null,
+                };
+        }
+    }
+
+    private getJudgement(response: ProblemResponse): Judgement {
+        // This should never happen, as we check for a problem in the calling
+        // function, but TypeScript does not know this.
+        if (!response.problem) {
+            return Judgement.UNKNOWN;
+        }
+        switch (response.type) {
+            case Dataset.SICK:
+                switch (response.problem.entailmentLabel) {
+                    case "ENTAILMENT":
+                        return Judgement.ENTAILMENT;
+                    case "CONTRADICTION":
+                        return Judgement.CONTRADICTION;
+                    case "NEUTRAL":
+                        return Judgement.NEUTRAL;
+                }
+            case Dataset.FRACAS:
+                switch (response.problem.fracasAnswer) {
+                    case "yes":
+                        return Judgement.ENTAILMENT;
+                    case "no":
+                        return Judgement.CONTRADICTION;
+                    case "unknown":
+                        return Judgement.NEUTRAL;
+                    case "undefined":
+                        return Judgement.UNKNOWN;
+                }
+            case Dataset.SNLI:
+                switch (response.problem.goldLabel) {
+                    case "entailment":
+                        return Judgement.ENTAILMENT;
+                    case "contradiction":
+                        return Judgement.CONTRADICTION;
+                    case "neutral":
+                        return Judgement.NEUTRAL;
+                    case "none":
+                        return Judgement.UNKNOWN;
+                }
+        }
+    }
 }

--- a/frontend/src/app/annotate/annotation-input/problem-details/problem-details.component.ts
+++ b/frontend/src/app/annotate/annotation-input/problem-details/problem-details.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed } from "@angular/core";
+import { Component, computed, input } from "@angular/core";
 import { Dataset, Judgement, ProblemResponse } from "../../../types";
 import { JudgementBadgeComponent } from "./judgement-badge/judgement-badge.component";
 import { faQuestionCircle } from "@fortawesome/free-solid-svg-icons";
@@ -16,6 +16,26 @@ export interface ProblemDetails {
     comment: string | null;
 }
 
+const judgementMap: Record<Dataset, Record<string, Judgement>> = {
+    [Dataset.SICK]: {
+        ENTAILMENT: Judgement.ENTAILMENT,
+        CONTRADICTION: Judgement.CONTRADICTION,
+        NEUTRAL: Judgement.NEUTRAL,
+    },
+    [Dataset.FRACAS]: {
+        yes: Judgement.ENTAILMENT,
+        no: Judgement.CONTRADICTION,
+        unknown: Judgement.NEUTRAL,
+        undefined: Judgement.UNKNOWN,
+    },
+    [Dataset.SNLI]: {
+        entailment: Judgement.ENTAILMENT,
+        contradiction: Judgement.CONTRADICTION,
+        neutral: Judgement.NEUTRAL,
+        none: Judgement.UNKNOWN,
+    },
+};
+
 @Component({
     selector: "la-problem-details",
     standalone: true,
@@ -24,9 +44,7 @@ export interface ProblemDetails {
     styleUrl: "./problem-details.component.scss",
 })
 export class ProblemDetailsComponent {
-    constructor(private annotateService: AnnotateService) {}
-
-    private problem = toSignal(this.annotateService.problem$);
+    public readonly problem = input.required<ProblemResponse | null>();
 
     public problemDetails = computed(() => {
         const problem = this.problem();
@@ -99,38 +117,25 @@ export class ProblemDetailsComponent {
         if (!response.problem) {
             return Judgement.UNKNOWN;
         }
-        switch (response.type) {
-            case Dataset.SICK:
-                switch (response.problem.entailmentLabel) {
-                    case "ENTAILMENT":
-                        return Judgement.ENTAILMENT;
-                    case "CONTRADICTION":
-                        return Judgement.CONTRADICTION;
-                    case "NEUTRAL":
-                        return Judgement.NEUTRAL;
-                }
-            case Dataset.FRACAS:
-                switch (response.problem.fracasAnswer) {
-                    case "yes":
-                        return Judgement.ENTAILMENT;
-                    case "no":
-                        return Judgement.CONTRADICTION;
-                    case "unknown":
-                        return Judgement.NEUTRAL;
-                    case "undefined":
-                        return Judgement.UNKNOWN;
-                }
-            case Dataset.SNLI:
-                switch (response.problem.goldLabel) {
-                    case "entailment":
-                        return Judgement.ENTAILMENT;
-                    case "contradiction":
-                        return Judgement.CONTRADICTION;
-                    case "neutral":
-                        return Judgement.NEUTRAL;
-                    case "none":
-                        return Judgement.UNKNOWN;
-                }
+
+        const { type, problem } = response;
+        // Use the judgementMap to get the judgement based on the dataset and
+        // the problem's entailment label or answer.
+        // TODO: move this to the backend.
+        const label =
+            type === Dataset.SICK
+                ? problem.entailmentLabel
+                : type === Dataset.FRACAS
+                ? problem.fracasAnswer
+                : type === Dataset.SNLI
+                ? problem.goldLabel
+                : undefined;
+
+        if (!label) {
+            // If the label is not defined, we return UNKNOWN.
+            return Judgement.UNKNOWN;
         }
+
+        return judgementMap[response.type][label];
     }
 }

--- a/frontend/src/app/services/annotate.service.ts
+++ b/frontend/src/app/services/annotate.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from "@angular/core";
-import { catchError, Observable, of, share, Subject, switchMap } from "rxjs";
+import { catchError, Observable, of, share, shareReplay, Subject, switchMap } from "rxjs";
 import { HttpClient } from "@angular/common/http";
 import { ProblemResponse, ProofBankStats } from "../types";
 
@@ -18,14 +18,14 @@ export class AnnotateService {
                 })
             )
         ),
-        share()
+        shareReplay(1)
     );
 
     public proofBankStats$: Observable<ProofBankStats | null> = this.http
         .get<ProofBankStats>("/api/problem/proofbank-stats")
         .pipe(
             catchError(() => {
-                console.error("Error fetching proof bank stats");
+                console.error("Error fetching ProofBank stats");
                 return of(null);
             })
         );


### PR DESCRIPTION
(Review after #33 )

A small bug: the 'problem details' (ID, judgement label, dataset etc.) do not show up if the page is loaded for the first time. This is because the template subscribes too late to catch the first emission.

![image](https://github.com/user-attachments/assets/9f7fa2f5-fb30-4df3-8921-01f83a811320)


I have added a `shareReplay` to the AnnotateService to fix this.

I have also moved code specifically aimed at formatting the ProblemDetails to the ProblemDetailsComponent, so the AnnotateInput component has less bloat.