### PR TITLE
Upgrade all-auth

### DIFF
--- a/backend/langpro_annotator/common_settings.py
+++ b/backend/langpro_annotator/common_settings.py
@@ -53,8 +53,8 @@ REST_FRAMEWORK = {
 }
 
 AUTH_USER_MODEL = "user.User"
-ACCOUNT_EMAIL_REQUIRED = True
 ACCOUNT_EMAIL_VERIFICATION = 'mandatory'
+ACCOUNT_SIGNUP_FIELDS = ["email*", "username*", "password1*", "password2*"]
 
 SITE_ID = 1
 SITE_NAME = "langpro_annotator"

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -26,7 +26,7 @@ django==4.2.20
     #   django-livereload-server
     #   django-revproxy
     #   djangorestframework
-django-allauth==65.5.0
+django-allauth==65.9.0
     # via -r requirements.in
 django-livereload-server==0.5.1
     # via -r requirements.in


### PR DESCRIPTION
This gets rid of a yellow deprecation warning (from `django-allauth`) and adds a grey one (from `dj-rest-auth`). I guess that is marginally better🤷‍♂️

There are several PRs waiting to be merged that fix this issue, e.g. https://github.com/iMerica/dj-rest-auth/pull/692.