### PR TITLE
Remove debug log level and volume permission flags

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,14 +46,13 @@ services:
         healthcheck:
             test: "curl -f localhost:8000/admin/"
         volumes:
-            - ./logs/django:/usr/src/app/logs:z
-            - ./seed/:/usr/src/app/backend/problem/data:z
+            - ./logs/django:/usr/src/app/logs
+            - ./seed/:/usr/src/app/backend/problem/data
         command: >
             gunicorn langpro_annotator.wsgi:application
             -w 4
             -b 0.0.0.0:8000
             --timeout 600
-            --log-level debug
             --access-logfile /usr/src/app/logs/access_log
             --error-logfile /usr/src/app/logs/error_log
             --capture-output


### PR DESCRIPTION
Removes two flags that were left in after deploying to the production server for the first time. I tested it locally and the log files are updated as expected.

(If you want to test this for yourself, you will probably have to temporarily add `localhost` to CSRF_TRUSTED_ORIGINS.)