### PR TITLE
Remove unused problem list view

### DIFF
--- a/backend/problem/views/problem.py
+++ b/backend/problem/views/problem.py
@@ -1,5 +1,4 @@
 from rest_framework.decorators import action
-from rest_framework.exceptions import MethodNotAllowed
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet
@@ -11,6 +10,7 @@ from rest_framework.status import (
 )
 from rest_framework.permissions import IsAuthenticated, IsAuthenticatedOrReadOnly
 
+from django.http import Http404
 from django.shortcuts import get_object_or_404
 
 from problem.problem_details import (
@@ -52,7 +52,7 @@ class ProblemView(ModelViewSet):
         return [IsAuthenticatedOrReadOnly()]
 
     def list(self, request: Request) -> Response:
-        raise MethodNotAllowed(request.method)
+        raise Http404
 
     @action(detail=False, methods=["get"], url_path="first")
     def first(self, request: Request) -> Response:

--- a/backend/problem/views/problem.py
+++ b/backend/problem/views/problem.py
@@ -1,4 +1,5 @@
 from rest_framework.decorators import action
+from rest_framework.exceptions import MethodNotAllowed
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet
@@ -51,18 +52,7 @@ class ProblemView(ModelViewSet):
         return [IsAuthenticatedOrReadOnly()]
 
     def list(self, request: Request) -> Response:
-        """
-        Lists all Problems in the database, with optional filtering.
-        """
-        filters = get_filters(request.query_params)
-
-        qs = self.get_queryset()
-
-        if filters is not None:
-            qs = qs.filter(filters)
-
-        serializer = self.get_serializer(qs, many=True)
-        return Response(serializer.data, status=HTTP_200_OK)
+        raise MethodNotAllowed(request.method)
 
     @action(detail=False, methods=["get"], url_path="first")
     def first(self, request: Request) -> Response:

--- a/backend/problem/views/problem_test.py
+++ b/backend/problem/views/problem_test.py
@@ -27,33 +27,6 @@ class TestProblemViewPermissions:
     Tests for problem view permissions as documented in the README.
     """
 
-    # List / browse
-
-    def test_unauthenticated_user_can_list_problems(self, client, sample_problem):
-        """Unauthenticated users should be able to browse problems (read-only)."""
-        response = client.get("/api/problem/")
-        assert response.status_code == status.HTTP_200_OK
-
-    def test_visitor_can_list_problems(self, client, visitor, sample_problem):
-        """Visitors should be able to browse problems."""
-        client.force_login(user=visitor)
-        response = client.get("/api/problem/")
-        assert response.status_code == status.HTTP_200_OK
-
-    def test_annotator_can_list_problems(self, client, annotator, sample_problem):
-        """Annotators should be able to browse problems."""
-        client.force_login(user=annotator)
-        response = client.get("/api/problem/")
-        assert response.status_code == status.HTTP_200_OK
-
-    def test_master_annotator_can_list_problems(
-        self, client, master_annotator, sample_problem
-    ):
-        """Master annotators should be able to browse problems."""
-        client.force_login(user=master_annotator)
-        response = client.get("/api/problem/")
-        assert response.status_code == status.HTTP_200_OK
-
     # Retrieve / browse single
 
     def test_unauthenticated_user_can_retrieve_problem(self, client, sample_problem):


### PR DESCRIPTION
This removes the unused `list()` method from `ProblemView`, probably from an earlier stage of development where we considered having a list. Everything seems to work perfectly without it.

We even had a few tests for a 'list' view in `TestProblemViewPermissions`. These keep working even after removing `.list()`, since `ModelViewSet` provides a default list method that simply returns the whole queryset. That is going to be a problem (see what I did there?) with the new 'hidden' feature on problems (#106).

To simplify things, I propose overriding the default list method and returning 404 NOT FOUND. The tests for the list view can then also go.